### PR TITLE
Fix stretchy buttons on new quick-reply

### DIFF
--- a/src/dwtools/js/code.js
+++ b/src/dwtools/js/code.js
@@ -31,7 +31,6 @@
     var commentThread;
     var nextButton;
     var oldLastComment;
-    var isPreviewPage = false;
 
     function saveSelection() {
         $textBox.data("lastSelection", $textBox.getSelection());
@@ -57,26 +56,30 @@
 
         //Adding buttons
 
+        // Respectively: quick-reply, old talkform, old preview form.
         $textBox = jQuery("#body, #commenttext, #previewform textarea.textbox");
         $textBox.focusout(saveSelection);
 
-        var subject = jQuery("#subject");
-        if (subject.length == 0) {
-            isPreviewPage = true;
+        var makeButton = (button, i) => `<input type="button" data-id="${i}" class="custom-button" value="${button.label}" />`;
+        var buttons =
+            '<div class="dwtools-custom-buttons">' +
+            DT['CUSTOMBUTTONS'].map( makeButton ).join(' ') +
+            '</div>';
+
+        // Try to insert between the subject and the body.
+        if ( jQuery('.qr-body').length > 0 ) {
+            // quick-reply or post-#2480 talkform. Insert above body's parent
+            // div. In mid-2019 quick-reply, this ends up above the subject, to
+            // avoid a stretchy flexbox situation. After #2522, it goes between.
+            jQuery('.qr-body').before(buttons);
+        } else if ( jQuery('.talkform #misc_controls').length > 0 ) {
+            // old talkform. Insert above message body, but don't misalign the
+            // "Message:" label.
+            jQuery('#misc_controls').after(buttons);
+        } else {
+            // old preview page, or something unexpected.
+            $textBox.before(buttons);
         }
-
-        for (var x = 0; x < DT['CUSTOMBUTTONS'].length; x++) {
-
-            if (isPreviewPage) {
-
-                jQuery('input[name=subject]').after(`<input type="button" data-id="${x}" class="custom-button" value="${DT['CUSTOMBUTTONS'][x].label}">`);
-            }
-            else {
-                subject.after(`<input type="button" class="custom-button" data-id="${x}" value="${DT['CUSTOMBUTTONS'][x].label}">`);
-            }
-
-        }
-
     }
 
     function CustomButtonTagInsert(ele) {

--- a/src/dwtools/js/code.js
+++ b/src/dwtools/js/code.js
@@ -57,25 +57,13 @@
 
         //Adding buttons
 
+        $textBox = jQuery("#body, #commenttext, #previewform textarea.textbox");
+        $textBox.focusout(saveSelection);
+
         var subject = jQuery("#subject");
         if (subject.length == 0) {
             isPreviewPage = true;
-            $textBox = jQuery("textarea.textbox");
-            $textBox.focusout(saveSelection);
-            $textBox.bind("beforedeactivate", function () {
-                saveSelection();
-                $textBox.unbind("focusout");
-            });
         }
-        else {
-            $textBox = jQuery("#body, #commenttext");
-            $textBox.focusout(saveSelection);
-            $(document).on("beforedeactivate", "#body", function () {
-                saveSelection();
-                $textBox.unbind("focusout");
-            });
-        }
-
 
         for (var x = 0; x < DT['CUSTOMBUTTONS'].length; x++) {
 

--- a/src/dwtools/js/code.js
+++ b/src/dwtools/js/code.js
@@ -70,7 +70,7 @@
         if ( jQuery('.qr-body').length > 0 ) {
             // quick-reply or post-#2480 talkform. Insert above body's parent
             // div. In mid-2019 quick-reply, this ends up above the subject, to
-            // avoid a stretchy flexbox situation. After #2522, it goes between.
+            // avoid a stretchy width: 100% situation. After #2522, it goes between.
             jQuery('.qr-body').before(buttons);
         } else if ( jQuery('.talkform #misc_controls').length > 0 ) {
             // old talkform. Insert above message body, but don't misalign the

--- a/src/dwtools/manifest.json
+++ b/src/dwtools/manifest.json
@@ -18,18 +18,12 @@
     {
       "run_at": "document_end",
       "matches": [
-        "http://*.dreamwidth.org/*.html*",
-        "http://www.dreamwidth.org/talkpost_do",
-        "https://*.dreamwidth.org/*.html*",
-        "https://www.dreamwidth.org/talkpost_do",
-        "http://dreamwidth.org/editicons",
-        "https://dreamwidth.org/editicons",
-        "http://www.dreamwidth.org/editicons",
-        "https://www.dreamwidth.org/editicons",
-        "http://www.dreamwidth.org/manage/icons",
-        "https://www.dreamwidth.org/manage/icons",
-        "http://dreamwidth.org/manage/icons",
-        "https://dreamwidth.org/manage/icons"
+        "*://*.dreamwidth.org/*.html*",
+        "*://www.dreamwidth.org/talkpost_do",
+        "*://www.dreamwidth.org/editicons",
+        "*://dreamwidth.org/editicons",
+        "*://www.dreamwidth.org/manage/icons",
+        "*://dreamwidth.org/manage/icons"
 
       ],
       "css": [

--- a/src/dwtools/manifest.json
+++ b/src/dwtools/manifest.json
@@ -19,6 +19,12 @@
       "run_at": "document_end",
       "matches": [
         "*://*.dreamwidth.org/*.html*",
+        "*://*.dreamwidth.org/",
+        "*://*.dreamwidth.org/?*",
+        "*://*.dreamwidth.org/*/*/*",
+        "*://*.dreamwidth.org/tag/*",
+        "*://*.dreamwidth.org/read*",
+        "*://*.dreamwidth.org/network*",
         "*://www.dreamwidth.org/talkpost_do",
         "*://www.dreamwidth.org/editicons",
         "*://dreamwidth.org/editicons",


### PR DESCRIPTION
Hi, I'm the one who switched up the layout on DW's quick-reply recently! Those style changes made this extension's custom buttons look bad, and some people asked me if I knew how to fix it. Here's my suggestions, which also take into account the upcoming (not yet merged) additional changes to that layout. 

Basically, right now the QR goes something like:

- div.qr-meta (icon stuff)
- div.qr-body (everything in here is set to width: 100%)
    - subject 
    - body
- div.qr-footer

Soon, it'll be more like this (and if the user joins a beta, the talkform will use almost the exact same layout):

- div.qr-meta (also has username and "more options" now)
- div.qr-subject (is a flex container)
    - subject
    - quote button
    - "subjecticon" (talkform only)
- div#subjectIconList (talkform only, usually is `display: none`ed)
- div.qr-body
- div.qr-footer

EVEN LATER, it might end up something like:

- div.qr-meta
- div.qr-subject (minus the quote button)
- div.qr-format
    - markup type selector (markdown, html, or raw html)
    - bold/italic/quote/link/image/list/etc.
- div.qr-body
- div.qr-footer

So as you can see, shimming your buttons in as an extra sibling div just above `.qr-body` (where available) should be the most future-proof way to get them somewhere useful and non-explody. That puts them above the subject today, which I know is annoying, but that shouldn't last too long (probably just the next code push).